### PR TITLE
log: set default inspect level to 5

### DIFF
--- a/examples/example-2.js
+++ b/examples/example-2.js
@@ -15,6 +15,12 @@ const obj = {
       name: 'I am a nested object'
     , nested: {
         a: 'even further'
+      , b: {
+          name: 'biscuits'
+        , friend: {
+            depth: 1
+          }
+        }
       }
     }
   }
@@ -27,8 +33,6 @@ log.silly('hello', { name: 'evan' })
 log.silly('hello', { name: 'evan' }, true)
 log.silly('hello', { name: 'evan' }, true, 5)
 log.silly(obj)
-log.inspect(obj)
-log.inspect(obj, 0)
 log.verbose('hello')
 log.info('hello')
 log.http('hello')

--- a/format.js
+++ b/format.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const util = require('util')
+const inspect = util.inspect
+const depth = 5
+
+module.exports = function format(f) {
+  if (typeof f !== 'string') {
+    const objects = new Array(arguments.length)
+    for (var index = 0; index < arguments.length; index++) {
+      objects[index] = inspect(arguments[index], {
+        depth: depth
+      })
+    }
+    return objects.join(' ')
+  }
+
+  var argLen = arguments.length
+
+  if (argLen === 1) return f
+
+  var str = ''
+  var a = 1
+  var lastPos = 0
+  for (var i = 0; i < f.length;) {
+    if (f.charCodeAt(i) === 37/*'%'*/ && i + 1 < f.length) {
+      switch (f.charCodeAt(i + 1)) {
+        case 100: // 'd'
+          if (a >= argLen)
+            break
+          if (lastPos < i)
+            str += f.slice(lastPos, i)
+          str += Number(arguments[a++])
+          lastPos = i = i + 2
+          continue
+        case 106: // 'j'
+          if (a >= argLen)
+            break
+          if (lastPos < i)
+            str += f.slice(lastPos, i)
+          str += tryStringify(arguments[a++])
+          lastPos = i = i + 2
+          continue
+        case 115: // 's'
+          if (a >= argLen)
+            break
+          if (lastPos < i)
+            str += f.slice(lastPos, i)
+          str += String(arguments[a++])
+          lastPos = i = i + 2
+          continue
+        case 37: // '%'
+          if (lastPos < i)
+            str += f.slice(lastPos, i)
+          str += '%'
+          lastPos = i = i + 2
+          continue
+      }
+    }
+    ++i
+  }
+  if (lastPos === 0)
+    str = f
+  else if (lastPos < f.length)
+    str += f.slice(lastPos)
+  while (a < argLen) {
+    const x = arguments[a++]
+    if (x === null || (typeof x !== 'object' && typeof x !== 'symbol')) {
+      str += ' ' + x
+    } else {
+      str += ' ' + inspect(x, {
+        depth: depth
+      })
+    }
+  }
+  return str
+}
+
+function tryStringify(arg) {
+  try {
+    return JSON.stringify(arg)
+  } catch (_) {
+    return '[Circular]'
+  }
+}

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const util = require('util')
 const mapUtil = require('map-util')
+const format = require('./format')
 
 const has = (obj, prop) => {
   return Object.prototype.hasOwnProperty.call(obj, prop)
@@ -194,20 +195,20 @@ Log.prototype.silly = function silly() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {
@@ -227,20 +228,20 @@ Log.prototype.verbose = function verbose() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {
@@ -260,20 +261,20 @@ Log.prototype.info = function info() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {
@@ -293,20 +294,20 @@ Log.prototype.http = function http() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {
@@ -326,20 +327,20 @@ Log.prototype.warn = function warn() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {
@@ -359,20 +360,20 @@ Log.prototype.error = function error() {
   let str
   switch (arguments.length) {
     case 1:
-      str = util.format(arguments[0])
+      str = format(arguments[0])
       break
     case 2:
-      str = util.format(arguments[0], arguments[1])
+      str = format(arguments[0], arguments[1])
       break
     case 3:
-      str = util.format(arguments[0], arguments[1], arguments[2])
+      str = format(arguments[0], arguments[1], arguments[2])
       break
     default:
       const args = new Array(arguments.length)
       for (var i = 0; i < args.length; i++) {
         args[i] = arguments[i]
       }
-      str = util.format.apply(util, args)
+      str = format.apply(util, args)
       break
   }
   str.split(splitRE).forEach((line) => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "check-pkg",
     "lint": "lintit",
     "pretest": "check-pkg && lintit",
-    "test": "tap test.js --cov"
+    "test": "tap test --cov"
   },
   "dependencies": {
     "map-util": "^2.1.1"

--- a/test/format.js
+++ b/test/format.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const util = require('util')
+const test = require('tap').test
+const format = require('../format')
+const symbol = Symbol('foo')
+
+// These are from node core which is MIT licensed.
+// https://github.com/nodejs/node/blob/master/test/parallel/test-util-format.js
+
+test('format()', (t) => {
+  t.equal(format(), '')
+  t.equal(format(''), '')
+  t.equal(format([]), '[]')
+  t.equal(format([0]), '[ 0 ]')
+  t.equal(format({}), '{}')
+  t.equal(format({foo: 42}), '{ foo: 42 }')
+  t.equal(format(null), 'null')
+  t.equal(format(true), 'true')
+  t.equal(format(false), 'false')
+  t.equal(format('test'), 'test')
+
+  t.equal(format('foo', 'bar', 'baz'), 'foo bar baz')
+  t.equal(format(symbol), 'Symbol(foo)')
+  t.equal(format('foo', symbol), 'foo Symbol(foo)')
+  t.equal(format('%s', symbol), 'Symbol(foo)')
+  t.equal(format('%j', symbol), 'undefined')
+  t.throws(() => {
+    format('%d', symbol)
+  }, TypeError)
+
+  t.equal(format('%d', 42.0), '42')
+  t.equal(format('%d', 42), '42')
+  t.equal(format('%s', 42), '42')
+  t.equal(format('%j', 42), '42')
+
+  t.equal(format('%d', '42.0'), '42')
+  t.equal(format('%d', '42'), '42')
+  t.equal(format('%s', '42'), '42')
+  t.equal(format('%j', '42'), '"42"')
+
+  t.equal(format('%%s%s', 'foo'), '%sfoo')
+
+  t.equal(format('%s'), '%s')
+  t.equal(format('%s', undefined), 'undefined')
+  t.equal(format('%s', 'foo'), 'foo')
+  t.equal(format('%s:%s'), '%s:%s')
+  t.equal(format('%s:%s', undefined), 'undefined:%s')
+  t.equal(format('%s:%s', 'foo'), 'foo:%s')
+  t.equal(format('%s:%s', 'foo', 'bar'), 'foo:bar')
+  t.equal(format('%s:%s', 'foo', 'bar', 'baz'), 'foo:bar baz')
+  t.equal(format('%%%s%%', 'hi'), '%hi%')
+  t.equal(format('%%%s%%%%', 'hi'), '%hi%%')
+  t.equal(format('%sbc%%def', 'a'), 'abc%def')
+
+  t.equal(format('%d:%d', 12, 30), '12:30')
+  t.equal(format('%d:%d', 12), '12:%d')
+  t.equal(format('%d:%d'), '%d:%d')
+
+  t.equal(format('o: %j, a: %j', {}, []), 'o: {}, a: []')
+  t.equal(format('o: %j, a: %j', {}), 'o: {}, a: %j')
+  t.equal(format('o: %j, a: %j'), 'o: %j, a: %j')
+
+  {
+    const o = {}
+    o.o = o
+    t.equal(format('%j', o), '[Circular]')
+  }
+
+  const err = new Error('foo')
+  t.equal(format(err), err.stack)
+
+  function CustomError(msg) {
+    Error.call(this)
+    Object.defineProperty(this, 'message', {
+      value: msg
+    , enumerable: false
+    })
+    Object.defineProperty(this, 'name', {
+      value: 'CustomError'
+    , enumerable: false
+    })
+    Error.captureStackTrace(this, CustomError)
+  }
+  util.inherits(CustomError, Error)
+
+  const customError = new CustomError('bar')
+  t.equal(format(customError), customError.stack)
+
+  // Doesn't capture stack trace
+  function BadCustomError(msg) {
+    Error.call(this)
+    Object.defineProperty(this, 'message', {
+      value: msg
+    , enumerable: false
+    })
+
+    Object.defineProperty(this, 'name', {
+      value: 'BadCustomError'
+    , enumerable: false
+    })
+  }
+  util.inherits(BadCustomError, Error)
+  t.equal(format(new BadCustomError('foo')), '[BadCustomError: foo]')
+  t.end()
+})

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ const exp1 = [
 
 test('log', (t) => {
   t.plan(exp1.length + 1)
-  const fp = path.join(__dirname, 'examples/example-1.js')
+  const fp = path.join(__dirname, '../examples/example-1.js')
   const child = spawn(process.execPath, [fp], {
     cwd: process.cwd()
   })
@@ -54,16 +54,11 @@ const exp2 = [
 , '[7msill[27m [96m     silly |[0m      b: true,'
 , '[7msill[27m [96m     silly |[0m      c: null,'
 , '[7msill[27m [96m     silly |[0m      d: false,'
-, '[7msill[27m [96m     silly |[0m      e: { name: \'I am a nested object\', nested: [Object] } } }'
-, '[94mINSP[0m [96m     silly |[0m { name: [32m\'evan\'[39m,'
-, '[94mINSP[0m [96m     silly |[0m   foo: [32m\'bar\'[39m,'
-, '[94mINSP[0m [96m     silly |[0m   out: '
-, '[94mINSP[0m [96m     silly |[0m    { a: [32m\'b\'[39m,'
-, '[94mINSP[0m [96m     silly |[0m      b: [33mtrue[39m,'
-, '[94mINSP[0m [96m     silly |[0m      c: [1mnull[22m,'
-, '[94mINSP[0m [96m     silly |[0m      d: [33mfalse[39m,'
-, '[94mINSP[0m [96m     silly |[0m      e: { name: [32m\'I am a nested object\'[39m, nested: { a: [32m\'even further\'[39m } } } }'
-, '[94mINSP[0m [96m     silly |[0m { name: [32m\'evan\'[39m, foo: [32m\'bar\'[39m, out: [36m[Object][39m }'
+, '[7msill[27m [96m     silly |[0m      e: '
+, '[7msill[27m [96m     silly |[0m       { name: \'I am a nested object\','
+, '[7msill[27m [96m     silly |[0m         nested: '
+, '[7msill[27m [96m     silly |[0m          { a: \'even further\','
+, '[7msill[27m [96m     silly |[0m            b: { name: \'biscuits\', friend: { depth: 1 } } } } } }'
 , '[94mverb[0m [96m     silly |[0m hello'
 , '[92minfo[0m [96m     silly |[0m hello'
 , '[32mhttp[0m [96m     silly |[0m hello'
@@ -108,7 +103,7 @@ const exp2 = [
 /* eslint-enable */
 test('log', (t) => {
   t.plan(exp2.length + 1)
-  const fp = path.join(__dirname, 'examples/example-2.js')
+  const fp = path.join(__dirname, '../examples/example-2.js')
   const child = spawn(process.execPath, [fp], {
     cwd: process.cwd()
   })
@@ -141,7 +136,7 @@ const exp3 = [
 
 test('log', (t) => {
   t.plan(exp3.length + 1)
-  const fp = path.join(__dirname, 'examples/example-3.js')
+  const fp = path.join(__dirname, '../examples/example-3.js')
   const child = spawn(process.execPath, [fp], {
     cwd: process.cwd()
   })


### PR DESCRIPTION
depth defaults to 2 in core, but we want more than that by default
without affecting other uses of util.inspect.

Semver: major